### PR TITLE
fix: recomposition 개선

### DIFF
--- a/domain/src/main/java/com/oreocube/booksearch/domain/model/Library.kt
+++ b/domain/src/main/java/com/oreocube/booksearch/domain/model/Library.kt
@@ -12,10 +12,4 @@ data class Library(
     val closedTime: String,
     val operatingTime: String,
     val bookCount: Long,
-    val isFavorite: Boolean = false,
-) {
-    fun toShort() = LibraryShort(
-        id = id,
-        name = name,
-    )
-}
+)

--- a/feature/book/build.gradle.kts
+++ b/feature/book/build.gradle.kts
@@ -7,6 +7,7 @@ android {
 }
 
 dependencies {
+    implementation(libs.kotlinx.collections.immutable)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/feature/book/src/main/java/com/oreocube/booksearch/feature/book/SearchBookScreen.kt
+++ b/feature/book/src/main/java/com/oreocube/booksearch/feature/book/SearchBookScreen.kt
@@ -32,7 +32,9 @@ import com.oreocube.booksearch.core.ui.component.BookSearchTextField
 import com.oreocube.booksearch.core.ui.theme.Gray10
 import com.oreocube.booksearch.core.ui.theme.Gray20
 import com.oreocube.booksearch.core.ui.theme.Gray40
-import com.oreocube.booksearch.domain.model.Book
+import com.oreocube.booksearch.feature.book.model.BookUiState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun SearchBookRoute(
@@ -100,7 +102,7 @@ fun SearchBookScreen(
 @Composable
 private fun SearchResult(
     modifier: Modifier = Modifier,
-    result: List<Book>,
+    result: ImmutableList<BookUiState>,
     onBookClick: (String) -> Unit
 ) {
     LazyColumn(modifier = modifier) {
@@ -121,7 +123,7 @@ private fun SearchResult(
 @Composable
 private fun BookItem(
     modifier: Modifier = Modifier,
-    book: Book,
+    book: BookUiState,
     onItemClick: () -> Unit
 ) {
     Row(
@@ -164,7 +166,7 @@ private fun BookItem(
 @Preview(showBackground = true)
 private fun BookItemPreview() {
     BookItem(
-        book = Book(
+        book = BookUiState(
             title = "실용주의 프로그래머 :20주년 기념판 ",
             authors = "데이비드 토머스,정지용 옮김",
             publisher = "인사이트",
@@ -197,7 +199,7 @@ private fun SearchBookScreenPreview2() {
         uiState = SearchBookUiState(
             query = "실용주의",
             result = listOf(
-                Book(
+                BookUiState(
                     title = "실용주의 프로그래머 :20주년 기념판 ",
                     authors = "데이비드 토머스,정지용 옮김",
                     publisher = "인사이트",
@@ -208,7 +210,7 @@ private fun SearchBookScreenPreview2() {
                     detailUrl = "https://data4library.kr/bookV?seq=6404790",
                     loanCount = 695
                 ),
-            )
+            ).toImmutableList()
         ),
         onInputChanged = {},
         onClearClicked = {},

--- a/feature/book/src/main/java/com/oreocube/booksearch/feature/book/SearchBookScreen.kt
+++ b/feature/book/src/main/java/com/oreocube/booksearch/feature/book/SearchBookScreen.kt
@@ -85,23 +85,36 @@ fun SearchBookScreen(
                 focusManager.clearFocus()
             },
         )
-        LazyColumn(modifier = Modifier.weight(1f)) {
-            uiState.result.forEachIndexed { index, book ->
-                item(key = book.isbn13) {
-                    BookItem(
-                        book = book,
-                        onItemClick = { onBookClick(book.isbn13) }
-                    )
-                    if (index != uiState.result.lastIndex) {
-                        HorizontalDivider(color = Gray40)
-                    }
-                }
-            }
-        }
+        SearchResult(
+            modifier = Modifier.weight(1f),
+            result = uiState.result,
+            onBookClick = onBookClick,
+        )
     }
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
+    }
+}
+
+@Composable
+private fun SearchResult(
+    modifier: Modifier = Modifier,
+    result: List<Book>,
+    onBookClick: (String) -> Unit
+) {
+    LazyColumn(modifier = modifier) {
+        result.forEachIndexed { index, book ->
+            item(key = book.isbn13) {
+                BookItem(
+                    book = book,
+                    onItemClick = { onBookClick(book.isbn13) }
+                )
+                if (index != result.lastIndex) {
+                    HorizontalDivider(color = Gray40)
+                }
+            }
+        }
     }
 }
 

--- a/feature/book/src/main/java/com/oreocube/booksearch/feature/book/SearchBookViewModel.kt
+++ b/feature/book/src/main/java/com/oreocube/booksearch/feature/book/SearchBookViewModel.kt
@@ -4,7 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.oreocube.booksearch.domain.model.Book
 import com.oreocube.booksearch.domain.usecase.SearchBooksUseCase
+import com.oreocube.booksearch.feature.book.model.BookUiState
+import com.oreocube.booksearch.feature.book.model.toUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -35,7 +40,10 @@ class SearchBookViewModel @Inject constructor(
         )
 
     val uiState: StateFlow<SearchBookUiState> = combine(_query, _searchResult) { query, result ->
-        SearchBookUiState(query = query, result = result)
+        SearchBookUiState(
+            query = query,
+            result = result.toImmutableList(),
+        )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(500),
@@ -46,9 +54,9 @@ class SearchBookViewModel @Inject constructor(
         _query.value = input
     }
 
-    private suspend fun searchBookSafely(query: String): List<Book> {
+    private suspend fun searchBookSafely(query: String): List<BookUiState> {
         return runCatching {
-            searchBooksUseCase(query)
+            searchBooksUseCase(query).map(Book::toUiState)
         }.getOrElse {
             _eventChannel.send(SearchBookUiEvent.Error("도서 검색에 실패했습니다."))
             emptyList()
@@ -58,7 +66,7 @@ class SearchBookViewModel @Inject constructor(
 
 data class SearchBookUiState(
     val query: String = "",
-    val result: List<Book> = emptyList(),
+    val result: ImmutableList<BookUiState> = persistentListOf(),
 )
 
 sealed class SearchBookUiEvent {

--- a/feature/book/src/main/java/com/oreocube/booksearch/feature/book/model/BookUiState.kt
+++ b/feature/book/src/main/java/com/oreocube/booksearch/feature/book/model/BookUiState.kt
@@ -1,0 +1,27 @@
+package com.oreocube.booksearch.feature.book.model
+
+import com.oreocube.booksearch.domain.model.Book
+
+data class BookUiState(
+    val title: String,
+    val authors: String,
+    val publisher: String,
+    val publicationYear: String,
+    val isbn13: String,
+    val vol: String,
+    val imageUrl: String,
+    val detailUrl: String,
+    val loanCount: Long,
+)
+
+fun Book.toUiState() = BookUiState(
+    title = title,
+    authors = authors,
+    publisher = publisher,
+    publicationYear = publicationYear,
+    isbn13 = isbn13,
+    vol = vol,
+    imageUrl = imageUrl,
+    detailUrl = detailUrl,
+    loanCount = loanCount
+)

--- a/feature/favorite/build.gradle.kts
+++ b/feature/favorite/build.gradle.kts
@@ -7,6 +7,7 @@ android {
 }
 
 dependencies {
+    implementation(libs.kotlinx.collections.immutable)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/feature/favorite/src/main/java/com/oreocube/booksearch/feature/favorite/FavoriteLibraryScreen.kt
+++ b/feature/favorite/src/main/java/com/oreocube/booksearch/feature/favorite/FavoriteLibraryScreen.kt
@@ -32,7 +32,10 @@ import com.oreocube.booksearch.core.ui.R
 import com.oreocube.booksearch.core.ui.component.BookSearchTopBar
 import com.oreocube.booksearch.core.ui.theme.Brown20
 import com.oreocube.booksearch.core.ui.theme.Gray20
-import com.oreocube.booksearch.domain.model.LibraryShort
+import com.oreocube.booksearch.feature.favorite.model.LibraryShortUiState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun FavoriteLibraryRoute(
@@ -128,7 +131,7 @@ private fun EmptyFavoriteLibraryContent(
 @Composable
 private fun FavoriteLibraryList(
     modifier: Modifier = Modifier,
-    libraries: List<LibraryShort>,
+    libraries: ImmutableList<LibraryShortUiState>,
     onStarClick: (String) -> Unit,
 ) {
     LazyColumn(modifier = modifier) {
@@ -147,8 +150,8 @@ private fun FavoriteLibraryList(
 @Composable
 private fun FavoriteLibraryItem(
     modifier: Modifier = Modifier,
-    library: LibraryShort,
-    onStarClick: (LibraryShort) -> Unit,
+    library: LibraryShortUiState,
+    onStarClick: (LibraryShortUiState) -> Unit,
 ) {
     Row(
         modifier = modifier
@@ -180,9 +183,9 @@ private fun FavoriteLibraryScreenPreview1() {
     FavoriteLibraryScreen(
         uiState = FavoriteLibraryUiState.Data(
             libraries = listOf(
-                LibraryShort(id = "11", name = "자바도서관"),
-                LibraryShort(id = "12", name = "코틀린도서관"),
-            )
+                LibraryShortUiState(id = "11", name = "자바도서관"),
+                LibraryShortUiState(id = "12", name = "코틀린도서관"),
+            ).toImmutableList(),
         ),
         onSearchClick = {},
         onStarClick = {},
@@ -194,7 +197,7 @@ private fun FavoriteLibraryScreenPreview1() {
 private fun FavoriteLibraryScreenPreview2() {
     FavoriteLibraryScreen(
         uiState = FavoriteLibraryUiState.Data(
-            libraries = emptyList()
+            libraries = persistentListOf()
         ),
         onSearchClick = {},
         onStarClick = {},

--- a/feature/favorite/src/main/java/com/oreocube/booksearch/feature/favorite/FavoriteLibraryViewModel.kt
+++ b/feature/favorite/src/main/java/com/oreocube/booksearch/feature/favorite/FavoriteLibraryViewModel.kt
@@ -5,7 +5,11 @@ import androidx.lifecycle.viewModelScope
 import com.oreocube.booksearch.domain.model.LibraryShort
 import com.oreocube.booksearch.domain.usecase.DeleteFavoriteLibraryUseCase
 import com.oreocube.booksearch.domain.usecase.GetFavoriteLibrariesUseCase
+import com.oreocube.booksearch.feature.favorite.model.LibraryShortUiState
+import com.oreocube.booksearch.feature.favorite.model.toUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -21,10 +25,11 @@ class FavoriteLibraryViewModel @Inject constructor(
     val uiState: StateFlow<FavoriteLibraryUiState> = getFavoriteLibrariesUseCase()
         .map { libraries ->
             FavoriteLibraryUiState.Data(
-                libraries = libraries,
+                libraries = libraries
+                    .map(LibraryShort::toUiState)
+                    .toImmutableList(),
             )
-        }
-        .stateIn(
+        }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(500),
             initialValue = FavoriteLibraryUiState.Loading,
@@ -40,6 +45,6 @@ class FavoriteLibraryViewModel @Inject constructor(
 sealed class FavoriteLibraryUiState {
     data object Loading : FavoriteLibraryUiState()
     data class Data(
-        val libraries: List<LibraryShort>,
+        val libraries: ImmutableList<LibraryShortUiState>,
     ) : FavoriteLibraryUiState()
 }

--- a/feature/favorite/src/main/java/com/oreocube/booksearch/feature/favorite/model/LibraryShortUiState.kt
+++ b/feature/favorite/src/main/java/com/oreocube/booksearch/feature/favorite/model/LibraryShortUiState.kt
@@ -1,0 +1,13 @@
+package com.oreocube.booksearch.feature.favorite.model
+
+import com.oreocube.booksearch.domain.model.LibraryShort
+
+data class LibraryShortUiState(
+    val id: String,
+    val name: String,
+)
+
+fun LibraryShort.toUiState() = LibraryShortUiState(
+    id = id,
+    name = name,
+)

--- a/feature/library/build.gradle.kts
+++ b/feature/library/build.gradle.kts
@@ -7,6 +7,7 @@ android {
 }
 
 dependencies {
+    implementation(libs.kotlinx.collections.immutable)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/feature/library/src/main/java/com/oreocube/booksearch/feature/library/SearchLibraryScreen.kt
+++ b/feature/library/src/main/java/com/oreocube/booksearch/feature/library/SearchLibraryScreen.kt
@@ -29,7 +29,7 @@ import com.oreocube.booksearch.core.ui.component.BookSearchTopBar
 import com.oreocube.booksearch.core.ui.theme.Brown20
 import com.oreocube.booksearch.core.ui.theme.Gray10
 import com.oreocube.booksearch.core.ui.theme.Gray20
-import com.oreocube.booksearch.domain.model.Library
+import com.oreocube.booksearch.feature.library.model.LibraryUiState
 
 @Composable
 fun SearchLibraryRoute(
@@ -62,7 +62,7 @@ fun SearchLibraryRoute(
 fun SearchLibraryScreen(
     uiState: SearchLibraryUiState,
     onBackClick: () -> Unit,
-    onStarClick: (Library) -> Unit,
+    onStarClick: (LibraryUiState) -> Unit,
     onCompleteClick: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
@@ -114,9 +114,9 @@ fun SearchLibraryScreen(
 @Composable
 private fun LibraryItem(
     modifier: Modifier = Modifier,
-    library: Library,
+    library: LibraryUiState,
     isFavorite: Boolean,
-    onStarClick: (Library) -> Unit,
+    onStarClick: (LibraryUiState) -> Unit,
 ) {
     val iconRes = if (isFavorite) R.drawable.ic_bookmark_filled_24
     else R.drawable.ic_bookmark_border_24
@@ -155,7 +155,7 @@ private fun LibraryItem(
 @Preview(showBackground = true)
 private fun LibraryItemPreview() {
     LibraryItem(
-        library = Library(
+        library = LibraryUiState(
             id = "11111",
             name = "도서관이름",
             address = "서울특별시 광진구",

--- a/feature/library/src/main/java/com/oreocube/booksearch/feature/library/SearchLibraryScreen.kt
+++ b/feature/library/src/main/java/com/oreocube/booksearch/feature/library/SearchLibraryScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -92,6 +91,7 @@ fun SearchLibraryScreen(
                             LibraryItem(
                                 modifier = Modifier.fillMaxWidth(),
                                 library = library,
+                                isFavorite = library.id in uiState.favoriteIds,
                                 onStarClick = onStarClick,
                             )
                         }
@@ -115,12 +115,11 @@ fun SearchLibraryScreen(
 private fun LibraryItem(
     modifier: Modifier = Modifier,
     library: Library,
+    isFavorite: Boolean,
     onStarClick: (Library) -> Unit,
 ) {
-    val iconRes = remember(library.isFavorite) {
-        if (library.isFavorite) R.drawable.ic_bookmark_filled_24
-        else R.drawable.ic_bookmark_border_24
-    }
+    val iconRes = if (isFavorite) R.drawable.ic_bookmark_filled_24
+    else R.drawable.ic_bookmark_border_24
 
     Row(
         modifier = modifier
@@ -169,6 +168,7 @@ private fun LibraryItemPreview() {
             operatingTime = "평일 09:00~22:00",
             bookCount = 11000,
         ),
+        isFavorite = false,
         onStarClick = {},
     )
 }

--- a/feature/library/src/main/java/com/oreocube/booksearch/feature/library/SearchLibraryViewModel.kt
+++ b/feature/library/src/main/java/com/oreocube/booksearch/feature/library/SearchLibraryViewModel.kt
@@ -10,7 +10,14 @@ import com.oreocube.booksearch.domain.usecase.AddFavoriteLibraryUseCase
 import com.oreocube.booksearch.domain.usecase.DeleteFavoriteLibraryUseCase
 import com.oreocube.booksearch.domain.usecase.GetFavoriteLibrariesUseCase
 import com.oreocube.booksearch.domain.usecase.GetLibrariesByRegionUseCase
+import com.oreocube.booksearch.feature.library.model.LibraryUiState
+import com.oreocube.booksearch.feature.library.model.toUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentSet
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -42,30 +49,30 @@ class SearchLibraryViewModel @Inject constructor(
     private val _eventChannel = Channel<SearchLibraryUiEvent>(Channel.BUFFERED)
     val eventFlow = _eventChannel.receiveAsFlow()
 
-    private val favoriteLibraryIds: StateFlow<Set<String>> = getFavoriteLibrariesUseCase()
-        .map { list -> list.map { it.id }.toSet() }
+    private val favoriteLibraryIds: StateFlow<PersistentSet<String>> = getFavoriteLibrariesUseCase()
+        .map { list -> list.map { it.id }.toPersistentSet() }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(500),
-            initialValue = emptySet(),
+            initialValue = persistentSetOf(),
         )
 
     val uiState: StateFlow<SearchLibraryUiState> = districtId
         .map { id ->
             getLibrariesByRegionUseCase(LibrarySearchParam(districtId = id))
+                .map(Library::toUiState)
+                .toPersistentList()
         }.combine(favoriteLibraryIds) { libraries, favoriteSet ->
             SearchLibraryUiState.Result(list = libraries, favoriteIds = favoriteSet)
-        }
-        .catch {
+        }.catch {
             _eventChannel.send(SearchLibraryUiEvent.Error("도서관을 불러오는데 실패했습니다."))
-        }
-        .stateIn(
+        }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(500),
             initialValue = SearchLibraryUiState.Loading,
         )
 
-    fun toggleLibraryStar(library: Library) {
+    fun toggleLibraryStar(library: LibraryUiState) {
         viewModelScope.launch {
             favoriteLibraryIds.first().let { idSet ->
                 if (library.id in idSet) {
@@ -81,8 +88,8 @@ class SearchLibraryViewModel @Inject constructor(
 sealed class SearchLibraryUiState {
     data object Loading : SearchLibraryUiState()
     data class Result(
-        val list: List<Library>,
-        val favoriteIds: Set<String>,
+        val list: ImmutableList<LibraryUiState>,
+        val favoriteIds: PersistentSet<String>,
     ) : SearchLibraryUiState()
 }
 

--- a/feature/library/src/main/java/com/oreocube/booksearch/feature/library/SearchLibraryViewModel.kt
+++ b/feature/library/src/main/java/com/oreocube/booksearch/feature/library/SearchLibraryViewModel.kt
@@ -54,8 +54,7 @@ class SearchLibraryViewModel @Inject constructor(
         .map { id ->
             getLibrariesByRegionUseCase(LibrarySearchParam(districtId = id))
         }.combine(favoriteLibraryIds) { libraries, favoriteSet ->
-            val searchResult = libraries.map { it.copy(isFavorite = it.id in favoriteSet) }
-            SearchLibraryUiState.Result(list = searchResult)
+            SearchLibraryUiState.Result(list = libraries, favoriteIds = favoriteSet)
         }
         .catch {
             _eventChannel.send(SearchLibraryUiEvent.Error("도서관을 불러오는데 실패했습니다."))
@@ -82,7 +81,8 @@ class SearchLibraryViewModel @Inject constructor(
 sealed class SearchLibraryUiState {
     data object Loading : SearchLibraryUiState()
     data class Result(
-        val list: List<Library>
+        val list: List<Library>,
+        val favoriteIds: Set<String>,
     ) : SearchLibraryUiState()
 }
 

--- a/feature/library/src/main/java/com/oreocube/booksearch/feature/library/model/LibraryUiState.kt
+++ b/feature/library/src/main/java/com/oreocube/booksearch/feature/library/model/LibraryUiState.kt
@@ -1,0 +1,38 @@
+package com.oreocube.booksearch.feature.library.model
+
+import com.oreocube.booksearch.domain.model.Library
+import com.oreocube.booksearch.domain.model.LibraryShort
+
+data class LibraryUiState(
+    val id: String,
+    val name: String,
+    val address: String,
+    val tel: String,
+    val fax: String?,
+    val latitude: String,
+    val longitude: String,
+    val homepageUrl: String,
+    val closedTime: String,
+    val operatingTime: String,
+    val bookCount: Long,
+    val isFavorite: Boolean = false,
+) {
+    fun toShort() = LibraryShort(
+        id = id,
+        name = name,
+    )
+}
+
+fun Library.toUiState() = LibraryUiState(
+    id = id,
+    name = name,
+    address = address,
+    tel = tel,
+    fax = fax,
+    latitude = latitude,
+    longitude = longitude,
+    homepageUrl = homepageUrl,
+    closedTime = closedTime,
+    operatingTime = operatingTime,
+    bookCount = bookCount
+)

--- a/feature/region/build.gradle.kts
+++ b/feature/region/build.gradle.kts
@@ -7,6 +7,7 @@ android {
 }
 
 dependencies {
+    implementation(libs.kotlinx.collections.immutable)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/feature/region/src/main/java/com/oreocube/booksearch/feature/region/RegionScreen.kt
+++ b/feature/region/src/main/java/com/oreocube/booksearch/feature/region/RegionScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -107,12 +108,13 @@ fun RegionScreen(
                     onCityClick = onCityClick,
                     onDistrictClick = onDistrictClick,
                 )
+                val currentDistrictId by rememberUpdatedState(uiState.selectedDistrictId)
                 BookSearchButton(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp),
                     text = stringResource(R.string.menu_search_library),
-                    onClick = { onSearchButtonClick(uiState.selectedDistrictId) }
+                    onClick = { onSearchButtonClick(currentDistrictId) }
                 )
             }
         }

--- a/feature/region/src/main/java/com/oreocube/booksearch/feature/region/RegionScreen.kt
+++ b/feature/region/src/main/java/com/oreocube/booksearch/feature/region/RegionScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -75,7 +74,7 @@ fun RegionScreen(
     onBackClick: () -> Unit = {},
     onCityClick: (Int) -> Unit = {},
     onDistrictClick: (Int) -> Unit = {},
-    onSearchButtonClick: (Int) -> Unit = {},
+    onSearchButtonClick: () -> Unit = {},
 ) {
     when (uiState) {
         is RegionUiState.Table -> {
@@ -108,13 +107,12 @@ fun RegionScreen(
                     onCityClick = onCityClick,
                     onDistrictClick = onDistrictClick,
                 )
-                val currentDistrictId by rememberUpdatedState(uiState.selectedDistrictId)
                 BookSearchButton(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp),
                     text = stringResource(R.string.menu_search_library),
-                    onClick = { onSearchButtonClick(currentDistrictId) }
+                    onClick = onSearchButtonClick,
                 )
             }
         }

--- a/feature/region/src/main/java/com/oreocube/booksearch/feature/region/RegionScreen.kt
+++ b/feature/region/src/main/java/com/oreocube/booksearch/feature/region/RegionScreen.kt
@@ -30,8 +30,10 @@ import com.oreocube.booksearch.core.ui.component.BookSearchTopBar
 import com.oreocube.booksearch.core.ui.theme.Brown10
 import com.oreocube.booksearch.core.ui.theme.Brown60
 import com.oreocube.booksearch.core.ui.theme.Gray80
-import com.oreocube.booksearch.domain.model.City
-import com.oreocube.booksearch.domain.model.District
+import com.oreocube.booksearch.feature.region.model.CityUiState
+import com.oreocube.booksearch.feature.region.model.DistrictUiState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
@@ -144,8 +146,8 @@ private fun RegionTable(
     modifier: Modifier = Modifier,
     selectedCityId: Int,
     selectedDistrictId: Int,
-    cities: List<City>,
-    districts: List<District>,
+    cities: ImmutableList<CityUiState>,
+    districts: ImmutableList<DistrictUiState>,
     onCityClick: (Int) -> Unit,
     onDistrictClick: (Int) -> Unit,
 ) {
@@ -225,13 +227,13 @@ private fun RegionScreenPreview() {
             selectedCityId = 11,
             selectedDistrictId = 11002,
             cities = listOf(
-                City(id = 11, name = "서울"),
-                City(id = 21, name = "대구"),
-            ),
+                CityUiState(id = 11, name = "서울"),
+                CityUiState(id = 21, name = "대구"),
+            ).toImmutableList(),
             districts = listOf(
-                District(id = 11001, cityId = 11, name = "강남구"),
-                District(id = 11002, cityId = 11, name = "강동구"),
-            )
+                DistrictUiState(id = 11001, cityId = 11, name = "강남구"),
+                DistrictUiState(id = 11002, cityId = 11, name = "강동구"),
+            ).toImmutableList(),
         )
     )
 }

--- a/feature/region/src/main/java/com/oreocube/booksearch/feature/region/RegionViewModel.kt
+++ b/feature/region/src/main/java/com/oreocube/booksearch/feature/region/RegionViewModel.kt
@@ -7,7 +7,13 @@ import com.oreocube.booksearch.domain.model.District
 import com.oreocube.booksearch.domain.model.param.DistrictSearchParam
 import com.oreocube.booksearch.domain.usecase.GetCitiesUseCase
 import com.oreocube.booksearch.domain.usecase.GetDistrictsUseCase
+import com.oreocube.booksearch.feature.region.model.CityUiState
+import com.oreocube.booksearch.feature.region.model.DistrictUiState
+import com.oreocube.booksearch.feature.region.model.toUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -42,7 +48,9 @@ class RegionViewModel @Inject constructor(
 
                 _uiState.value = RegionUiState.Table(
                     selectedCityId = selectedCityId,
-                    cities = cities,
+                    cities = cities
+                        .map(City::toUiState)
+                        .toImmutableList(),
                 )
 
                 if (selectedCityId != UNSELECTED) {
@@ -64,7 +72,9 @@ class RegionViewModel @Inject constructor(
                         state.copy(
                             selectedCityId = id,
                             selectedDistrictId = UNSELECTED,
-                            districts = districts,
+                            districts = districts
+                                .map(District::toUiState)
+                                .toImmutableList(),
                         )
                     } else {
                         state
@@ -107,8 +117,8 @@ sealed class RegionUiState {
     data class Table(
         val selectedCityId: Int,
         val selectedDistrictId: Int = -1,
-        val cities: List<City>,
-        val districts: List<District> = emptyList(),
+        val cities: ImmutableList<CityUiState>,
+        val districts: ImmutableList<DistrictUiState> = persistentListOf(),
     ) : RegionUiState()
 }
 

--- a/feature/region/src/main/java/com/oreocube/booksearch/feature/region/RegionViewModel.kt
+++ b/feature/region/src/main/java/com/oreocube/booksearch/feature/region/RegionViewModel.kt
@@ -86,12 +86,13 @@ class RegionViewModel @Inject constructor(
         }
     }
 
-    fun onSearchButtonClicked(id: Int) {
+    fun onSearchButtonClicked() {
+        val cachedState = uiState.value as? RegionUiState.Table ?: return
         viewModelScope.launch {
-            if (id == -1) {
+            if (cachedState.selectedDistrictId == UNSELECTED) {
                 _eventChannel.send(RegionUiEvent.Error("지역을 선택해주세요."))
             } else {
-                _eventChannel.send(RegionUiEvent.NavigateToSearchBook(id))
+                _eventChannel.send(RegionUiEvent.NavigateToSearchBook(cachedState.selectedDistrictId))
             }
         }
     }

--- a/feature/region/src/main/java/com/oreocube/booksearch/feature/region/model/CityUiState.kt
+++ b/feature/region/src/main/java/com/oreocube/booksearch/feature/region/model/CityUiState.kt
@@ -1,0 +1,13 @@
+package com.oreocube.booksearch.feature.region.model
+
+import com.oreocube.booksearch.domain.model.City
+
+data class CityUiState(
+    val id: Int,
+    val name: String,
+)
+
+fun City.toUiState() = CityUiState(
+    id = id,
+    name = name,
+)

--- a/feature/region/src/main/java/com/oreocube/booksearch/feature/region/model/DistrictUiState.kt
+++ b/feature/region/src/main/java/com/oreocube/booksearch/feature/region/model/DistrictUiState.kt
@@ -1,0 +1,15 @@
+package com.oreocube.booksearch.feature.region.model
+
+import com.oreocube.booksearch.domain.model.District
+
+data class DistrictUiState(
+    val id: Int,
+    val cityId: Int,
+    val name: String,
+)
+
+fun District.toUiState() = DistrictUiState(
+    id = id,
+    cityId = cityId,
+    name = name,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ coreKtx = "1.10.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
+kotlinxCollectionsImmutable = "0.3.8"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.04.01"
@@ -51,6 +52,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
+kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
**수정사항**
- 불필요한 객체 재생성 제거
- 불필요한 참조 제거
- 컴포저블 분리
- UI 모델 분리 (도메인 모델 곧장 사용하지 않기...)

**compose metrics 보고서 생성 방법**
```kotlin
kotlinOptions {
    freeCompilerArgs += listOf(
        "-P", "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${rootProject.file(".").absolutePath}/compose-metrics",
        "-P", "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${rootProject.file(".").absolutePath}/compose-reports"
    )
}
```